### PR TITLE
Fix msg code for failed observation

### DIFF
--- a/src/coap_interaction.c
+++ b/src/coap_interaction.c
@@ -494,7 +494,7 @@ CoAP_Result_t _rom CoAP_HandleObservationInReq(CoAP_Interaction_t* pIA) {
 	CoAP_Observer_t* pExistingObserver = (pIA->pRes)->pListObservers;
 
 	if (pIA->pRes->Notifier == NULL) {
-		return COAP_ERR_NOT_FOUND;            //resource does not support observe
+		return COAP_OBSERVE_NOT_FOUND;            //resource does not support observe
 	}
 	if ((res = GetObserveOptionFromMsg(pIA->pReqMsg, &obsVal)) != COAP_OK) {
 		return res; //if no observe option in req function can't do anything
@@ -576,7 +576,7 @@ CoAP_Result_t _rom CoAP_HandleObservationInReq(CoAP_Interaction_t* pIA) {
 		return COAP_BAD_OPTION_VAL;
 	}
 
-	return COAP_ERR_NOT_FOUND;
+	return COAP_OBSERVE_NOT_FOUND;
 }
 
 void _rom CoAP_ClearInteractions(CoAP_Interaction_t **pIA) {

--- a/src/coap_main.c
+++ b/src/coap_main.c
@@ -728,16 +728,23 @@ static void handleServerInteraction(CoAP_Interaction_t* pIA) {
 
 		//handle for GET observe option
 		if ((pIA->pReqMsg->Code == REQ_GET || pIA->pReqMsg->Code == REQ_FETCH) && pIA->pRespMsg->Code == RESP_SUCCESS_CONTENT_2_05) {
-			CoAP_Result_t result = CoAP_HandleObservationInReq(pIA);
-			if (result == COAP_OK) { //<---- attach OBSERVER to resource
-				AddObserveOptionToMsg(pIA->pRespMsg, 0);  //= ACK observation to client
-				INFO("- Observation activated\r\n");
-			} else if (result == COAP_REMOVED) {
-				INFO("- Observation actively removed by client\r\n");
-			} else {
-				INFO("- Observation failed\r\n");
+			switch ( CoAP_HandleObservationInReq(pIA) )
+			{
+				case COAP_OK:
+					AddObserveOptionToMsg(pIA->pRespMsg, 0);  //= ACK observation to client
+					INFO("- Observation activated\r\n");
+					break;
+				case COAP_REMOVED:
+					INFO("- Observation actively removed by client\r\n");
+					break;
+				case COAP_OBSERVE_NOT_FOUND:
+					INFO("- No Observe option in request message\r\n");
+					break;
+				default:
+					pIA->pRespMsg->Code = RESP_NOT_FOUND_4_04;
+					INFO("- Observation failed\r\n");
+					break;	
 			}
-
 		}
 
 		//handle non sendable NON and response send cases. Left in the end intentionally due to possibile

--- a/src/coap_resource.c
+++ b/src/coap_resource.c
@@ -530,7 +530,7 @@ CoAP_Result_t _rom CoAP_MatchObserverFromList(CoAP_Observer_t** pObserverList, C
 		}
 		pObserver = pObserver->next;
 	}
-	return COAP_ERR_NOT_FOUND;
+	return COAP_OBSERVE_NOT_FOUND;
 }
 
 CoAP_Result_t _rom CoAP_MatchObserverUsingTransportCtxFromList(CoAP_Observer_t **pObserverList,

--- a/src/liblobaro_coap.h
+++ b/src/liblobaro_coap.h
@@ -41,6 +41,7 @@ extern "C" {
 typedef enum {
 	COAP_OK = 0,
 	COAP_NOT_FOUND, //not found but no error
+	COAP_OBSERVE_NOT_FOUND, //Observe not found but no error
 	COAP_PARSE_DATAGRAM_TOO_SHORT,
 	COAP_PARSE_UNKOWN_COAP_VERSION,
 	COAP_PARSE_MESSAGE_FORMAT_ERROR,

--- a/src/option-types/coap_option_observe.c
+++ b/src/option-types/coap_option_observe.c
@@ -89,7 +89,7 @@ CoAP_Result_t _rom GetObserveOptionFromMsg(CoAP_Message_t* msg, uint32_t* val) {
 
 		pOpts = pOpts->next;
 	}
-	return COAP_NOT_FOUND;
+	return COAP_OBSERVE_NOT_FOUND;
 }
 
 CoAP_Observer_t* _rom CoAP_AllocNewObserver()


### PR DESCRIPTION
Before this bugfix, when observation fails on server, server always sends 2.05, but it should send 4.04 (as described in No Observe option in request message).